### PR TITLE
Fix: Docker Image Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This package is also available as Docker Container.
 
 ### TL;DR
 ```shell
-docker run -p 8080:8080 -d driverpt/aws-lambda-api-simulator
+docker run -p 8080:8080 -d driverpt/aws-lambda-runtime-simulator
 ```
 
 Start your handler by setting `AWS_LAMBDA_RUNTIME_API` Env Var to `localhost:8080`


### PR DESCRIPTION
Hiya! First time contributor here.

## What

- [x] update the docker image example in `README` to `aws-lambda-runtime-simulator`

## Why

I presume `aws-lambda-api-simulator` is deprecated / was a test build / separate project and `aws-lambda-runtime-simulator` is the right image corresponding to this project, so figured I'd fix the docs